### PR TITLE
Added Mortal.Kombat.11-EMPRESS

### DIFF
--- a/cat
+++ b/cat
@@ -25,6 +25,7 @@
 31. Dragon.Ball.FighterZ.Android.21-EMPRESS
 32. Monster.Hunter.Rise.Sunbreak-EMPRESS
 33. Assassins.Creed.Valhalla.Complete.Edition-EMPRESS
+34. Mortal.Kombat.11-EMPRESS
 3. Immortals.Fenyx.Rising.Crackfix.V2-EMPRESS
 4. Forza.Horizon.4.PROPER-EMPRESS
 5. Assassins.Creed.Valhalla.Repack-EMPRESS

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,5 @@
 const games = [
+    'Mortal.Kombat.11-EMPRESS',
     'Assassins.Creed.Valhalla.Complete.Edition-EMPRESS',
     'Hogwarts.Legacy.Deluxe.Edition-EMPRESS',
     'Monster.Hunter.Rise.Sunbreak-EMPRESS',
@@ -37,6 +38,7 @@ const games = [
 ];
 
 const nfoLinks = [
+    'https://nfomation.net/info/1682008157.EMPRESS.nfo',
     'https://nfomation.net/info/1681489866.EMPRESS.nfo',
     'https://nfomation.net/info/1677131115.EMPRESS.nfo',
     'https://nfomation.net/info/1676962149.EMPRESS.nfo',


### PR DESCRIPTION
Hi there,

I have made this change in this pull request:

<ol>
        <li>Added Mortal.Kombat.11-EMPRESS to the list of available <code>.nfo</code> files.</li>
</ol>

I have also tried to get the <code>.nfo</code> files from the games mentioned on the #1 issue but unfortunately it seems that EMPRESS either deleted them or uploaded them on another platform besides 1337.to
<br/>
### The results for SOULCALIBUR VI:

![SOULCALIBUR VI](https://user-images.githubusercontent.com/80352323/233440780-c2d3427c-9717-42f0-8fea-b4e37e9c2843.png)
<br/>
### The results for Anno 1800

![Anno 1800](https://user-images.githubusercontent.com/80352323/233441198-03176798-5c3c-4442-849d-20a24cdbdd41.png)
<br/>
As you can see, there was a Anno.1800.Digital.Deluxe.Edition-EMPRESS but it did not contain the original EMPRESS <code>.nfo</code> file.
<br/>